### PR TITLE
Add Flowers dataset modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,10 @@
         "@react-three/fiber": "^9.1.2",
         "@tailwindcss/cli": "^4.1.7",
         "@tailwindcss/vite": "^4.1.7",
+        "chart.js": "^4.4.9",
         "framer-motion": "^12.12.2",
         "react": "^19.1.0",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.0",
         "three": "^0.176.0"
       },
@@ -1037,6 +1039,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@mediapipe/tasks-vision": {
       "version": "0.10.17",
@@ -2723,6 +2731,18 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chart.js": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
+      "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -4238,6 +4258,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
     "@react-three/fiber": "^9.1.2",
     "@tailwindcss/cli": "^4.1.7",
     "@tailwindcss/vite": "^4.1.7",
+    "chart.js": "^4.4.9",
     "framer-motion": "^12.12.2",
     "react": "^19.1.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.0",
     "three": "^0.176.0"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import MotorWindingModal from "./MotorWindingModal";
 import FlashlightPanel from "./FlashlightPanel";
 import IframeModal from "./IframeModal";
 import { Modal } from "./components/Modal";
+import FlowersDatasetModal from "./FlowersDatasetModal";
 
 export default function App() {
   const [modal1Open, setModal1Open] = useState(false);
@@ -17,6 +18,7 @@ export default function App() {
   const [flashlightOpen, setFlashlightOpen] = useState(false);
   const [octopusOpen, setOctopusOpen] = useState(false);
   const [sparkleOpen, setSparkleOpen] = useState(false);
+  const [flowersOpen, setFlowersOpen] = useState(false);
 
   return (
     <div className="flex flex-col gap-4 bg-gray-800 p-8"
@@ -48,6 +50,7 @@ export default function App() {
       <button onClick={() => setFlashlightOpen(true)}>Flashlight Demo</button>
       <button onClick={() => setOctopusOpen(true)}>Octopus p5.js</button>
       <button onClick={() => setSparkleOpen(true)}>Sparkle Grid</button>
+      <button onClick={() => setFlowersOpen(true)}>Flowers Dataset</button>
 
       {modal1Open && (
         <Modal1
@@ -96,6 +99,9 @@ export default function App() {
           width={700}
           height={500}
         />
+      )}
+      {flowersOpen && (
+        <FlowersDatasetModal onClose={() => setFlowersOpen(false)} />
       )}
     </div>
   );

--- a/src/FlowersDatasetModal.tsx
+++ b/src/FlowersDatasetModal.tsx
@@ -1,0 +1,88 @@
+import { Modal } from "./components/Modal";
+import { Bar, Pie, Scatter } from "react-chartjs-2";
+import { Chart, CategoryScale, LinearScale, PointElement, BarElement, ArcElement } from "chart.js";
+import type { ScatterDataPoint } from "chart.js";
+import { useMemo } from "react";
+
+Chart.register(CategoryScale, LinearScale, PointElement, BarElement, ArcElement);
+
+interface FlowersDatasetModalProps {
+  onClose: () => void;
+}
+
+export default function FlowersDatasetModal({ onClose }: FlowersDatasetModalProps) {
+  // Mock counts for Kaggle Flowers dataset classes
+  const classes = useMemo(() => ["daisy", "dandelion", "rose", "sunflower", "tulip"], []);
+  const counts = [769, 1052, 784, 734, 984];
+
+  const scatterData = useMemo(() => {
+    // generate random feature pairs for each class
+    const points: ScatterDataPoint[] = [];
+    classes.forEach((_, idx) => {
+      for (let i = 0; i < 20; i++) {
+        points.push({
+          x: Math.random() * 5 + idx * 1.5,
+          y: Math.random() * 5 + idx,
+        });
+      }
+    });
+    return {
+      datasets: [
+        {
+          label: "Random feature scatter",
+          data: points,
+          backgroundColor: "rgba(99, 102, 241, 0.6)",
+        },
+      ],
+    };
+  }, [classes]);
+
+  return (
+    <Modal onClose={onClose} width={700} height={600}>
+      <h2 className="text-lg font-bold mb-4">Flowers Dataset</h2>
+      <div className="grid grid-cols-2 gap-4" style={{height: '90%'}}>
+        <Bar
+          data={{
+            labels: classes,
+            datasets: [
+              {
+                label: 'Image count',
+                data: counts,
+                backgroundColor: [
+                  '#f87171',
+                  '#fbbf24',
+                  '#34d399',
+                  '#60a5fa',
+                  '#a78bfa',
+                ],
+              },
+            ],
+          }}
+          options={{ plugins: { legend: { display: false } }, responsive: true, maintainAspectRatio: false }}
+        />
+        <Pie
+          data={{
+            labels: classes,
+            datasets: [
+              {
+                data: counts,
+                backgroundColor: [
+                  '#f87171',
+                  '#fbbf24',
+                  '#34d399',
+                  '#60a5fa',
+                  '#a78bfa',
+                ],
+              },
+            ],
+          }}
+          options={{ responsive: true, maintainAspectRatio: false }}
+        />
+        <Scatter
+          data={scatterData}
+          options={{ scales: { x: { beginAtZero: true }, y: { beginAtZero: true } }, responsive: true, maintainAspectRatio: false }}
+        />
+      </div>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary
- show Kaggle Flowers dataset button
- implement `FlowersDatasetModal` with bar, pie and scatter charts
- install Chart.js dependencies

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a35531fc4832e962f742e6ab33d7e